### PR TITLE
Fix warnings on PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: php
 
 sudo: false
 
-php:
-  - 7
-  - 7.1
-  - 7.2
-  - nightly
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
 
-env: TMPDIR=/tmp USE_XDEBUG=false
+env:
+  global:
+    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
 
 branches:
   only:
@@ -16,7 +17,7 @@ branches:
 
 install:
   - phpenv rehash
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-source $COMPOSER_ARGS
 
 stages:
   - test
@@ -35,18 +36,34 @@ jobs:
   allow_failures:
     - php: nightly
   include:
+    - php: 7
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7
+    - php: 7.1
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.1
+    - php: 7.2
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.2
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs"
+
     - stage: style check
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer style-check
+
     - stage: phpstan analysis
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer phpstan
+
     - stage: test with coverage
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=true CC_TEST_REPORTER_ID=595ba3feba676216fb19a1836a7fbb564580f5dbecca9aa7d4e12ccbf7968e5c
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
From our zf1 repo I noticed that this component was throwing a couple of warnings in php 7.3 (nightly):

>strstr(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior

Going to get these tests to hopefully run on 7.3 (nightly) properly, then fix warnings.