### PR TITLE
adding PHPUnit 7 support, bumping minimum php version (due to return hints)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
+    - COMPOSER_ARGS=""
+    - TMPDIR=/tmp
+    - USE_XDEBUG=false
+    - COMPOSER_DISCARD_CHANGES=1
 
 branches:
   only:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "diablomedia/zendframework1-exception": "^1.0.0",
         "diablomedia/zendframework1-loader": "^1.0.0",
         "diablomedia/zendframework1-registry": "^1.0.0",
@@ -22,8 +22,8 @@
         "diablomedia/zendframework1-filter": "^1.0.0",
         "diablomedia/zendframework1-layout": "^1.0.0",
         "diablomedia/zendframework1-session": "^1.0.0",
-        "phpunit/phpunit": "^6.0",
-        "phpunit/dbunit": "^3.0.2",
+        "phpunit/phpunit": "^6.0|^7.0",
+        "phpunit/dbunit": "^3.0.2|^4.0",
         "sebastian/comparator": "^2.1"
     },
     "autoload": {
@@ -42,7 +42,7 @@
         "diablomedia/zendframework1-controller-action-helper-json": "*",
         "friendsofphp/php-cs-fixer": "^2.11",
         "maglnet/composer-require-checker": "^1.1.0",
-        "phpro/grumphp": "^0.14.0"
+        "phpro/grumphp": "^0.15.0"
     },
     "archive": {
         "exclude": ["/tests"]

--- a/src/Zend/Test/PHPUnit/Constraint/DomQuery41.php
+++ b/src/Zend/Test/PHPUnit/Constraint/DomQuery41.php
@@ -217,7 +217,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery41 extends PHPUnit\Framework\Constrai
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = null)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = null): void
     {
         switch ($this->_assertType) {
             case self::ASSERT_CONTENT_CONTAINS:
@@ -271,7 +271,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery41 extends PHPUnit\Framework\Constrai
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return '';
     }

--- a/src/Zend/Test/PHPUnit/Constraint/Redirect41.php
+++ b/src/Zend/Test/PHPUnit/Constraint/Redirect41.php
@@ -174,7 +174,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit\Framework\Constrai
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = null)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = null): void
     {
         switch ($this->_assertType) {
             case self::ASSERT_REDIRECT_TO:
@@ -221,7 +221,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit\Framework\Constrai
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return '';
     }

--- a/src/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
+++ b/src/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
@@ -196,7 +196,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit\Framework\Co
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = null)
+    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = null): void
     {
         switch ($this->_assertType) {
             case self::ASSERT_RESPONSE_CODE:
@@ -246,7 +246,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit\Framework\Co
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return '';
     }

--- a/src/Zend/Test/PHPUnit/Db/Connection.php
+++ b/src/Zend/Test/PHPUnit/Db/Connection.php
@@ -71,7 +71,7 @@ class Zend_Test_PHPUnit_Db_Connection extends PHPUnit\DbUnit\Database\DefaultCon
      *
      * @return void
      */
-    public function close()
+    public function close(): void
     {
         $this->_connection->closeConnection();
     }

--- a/src/Zend/Test/PHPUnit/Db/DataSet/DbTable.php
+++ b/src/Zend/Test/PHPUnit/Db/DataSet/DbTable.php
@@ -90,7 +90,7 @@ class Zend_Test_PHPUnit_Db_DataSet_DbTable extends PHPUnit\DbUnit\DataSet\QueryT
      *
      * @return void
      */
-    protected function loadData()
+    protected function loadData(): void
     {
         if ($this->data === null) {
             $this->data = $this->_table->fetchAll(
@@ -108,7 +108,7 @@ class Zend_Test_PHPUnit_Db_DataSet_DbTable extends PHPUnit\DbUnit\DataSet\QueryT
     /**
      * Create Table Metadata object
      */
-    protected function createTableMetaData()
+    protected function createTableMetaData(): void
     {
         if ($this->tableMetaData === null) {
             $this->loadData();

--- a/src/Zend/Test/PHPUnit/Db/DataSet/QueryDataSet.php
+++ b/src/Zend/Test/PHPUnit/Db/DataSet/QueryDataSet.php
@@ -53,7 +53,7 @@ class Zend_Test_PHPUnit_Db_DataSet_QueryDataSet extends PHPUnit\DbUnit\DataSet\Q
      * @param string                $tableName
      * @param string|Zend_Db_Select $query
      */
-    public function addTable($tableName, $query = null)
+    public function addTable($tableName, $query = null): void
     {
         if ($query === null) {
             $query = $this->databaseConnection->getConnection()->select();

--- a/src/Zend/Test/PHPUnit/Db/DataSet/QueryTable.php
+++ b/src/Zend/Test/PHPUnit/Db/DataSet/QueryTable.php
@@ -53,7 +53,7 @@ class Zend_Test_PHPUnit_Db_DataSet_QueryTable extends PHPUnit\DbUnit\DataSet\Que
      *
      * @return void
      */
-    protected function loadData()
+    protected function loadData(): void
     {
         if ($this->data === null) {
             $stmt       = $this->databaseConnection->getConnection()->query($this->query);
@@ -64,7 +64,7 @@ class Zend_Test_PHPUnit_Db_DataSet_QueryTable extends PHPUnit\DbUnit\DataSet\Que
     /**
      * Create Table Metadata
      */
-    protected function createTableMetaData()
+    protected function createTableMetaData(): void
     {
         if ($this->tableMetaData === null) {
             $this->loadData();


### PR DESCRIPTION
In order to add support for this to run in PHP Unit 7, return type hints had to be added to some methods. Due to the `: void` return types, PHP 7.1 is now a minimum requirement (this will be a major release version bump).

Left PHP Unit 6.0 support in, which still works, even with the type hint additions.