### PR TITLE
allowing sebastian/comparator 3.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "diablomedia/zendframework1-session": "^1.0.0",
         "phpunit/phpunit": "^6.0|^7.0",
         "phpunit/dbunit": "^3.0.2|^4.0",
-        "sebastian/comparator": "^2.1"
+        "sebastian/comparator": "^2.1|^3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Had an issue installing this lib in another lib with a fresh vendor directory, allowing this version of this package resolved it.